### PR TITLE
Images With Colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /binpic
 /tmp/*
+
+*.exe

--- a/README.md
+++ b/README.md
@@ -13,11 +13,18 @@ Encode a file as [grayscale image](https://golang.org/pkg/image/#Gray), optional
 ```shell
 $ binpic -h
 Usage of binpic:
+  -color
+        produce an image with colored pixels
+  -d    decode a binpic-ed png (XXX: not yet implemented)
   -o string
         output file, will be a PNG (default "output.png")
   -resize string
         resize, if set (default "0x0")
+  -version
+        show version
 ```
+
+Take care to put the options before the file to decode.
 
 Thanks to the beautiful Go standard library packages like
 [image](https://golang.org/pkg/image/) and [io](https://golang.org/pkg/io/),

--- a/cmd/binpic/main.go
+++ b/cmd/binpic/main.go
@@ -18,7 +18,8 @@ import (
 	"github.com/disintegration/imaging"
 )
 
-const Version = "0.1.0"
+// Version is the current version of this tool.
+const Version = "0.2.0"
 
 var (
 	decode  = flag.Bool("d", false, "decode a binpic-ed png (XXX: not yet implemented)")


### PR DESCRIPTION
I extended your tool to be able to generate images with colored pixels. See picture of `binpic` below. The same algorithm as in my [`bin2img`](https://github.com/c3er/bin2img) is used.

Additionally, I increased the version and extended the README reflecting the changes.

![binpic with colors](https://user-images.githubusercontent.com/24460532/61566749-714cc000-aa7d-11e9-8dd7-0bb1a1aa9eeb.png)